### PR TITLE
fix toggleTimeMode to not change day

### DIFF
--- a/components/utils/time.js
+++ b/components/utils/time.js
@@ -287,7 +287,7 @@ const time = {
     const newDate = this.clone(d);
     const hours = newDate.getHours();
 
-    newDate.setHours(hours - (hours > 12 ? -12 : 12));
+    newDate.setHours(hours + (hours > 12 ? -12 : 12));
     return newDate;
   },
 


### PR DESCRIPTION
switch the addHours sign to keep the date within the same day when changing between AM and PM